### PR TITLE
fix: prevent horizontal overflow causing missing right-edge padding on mobile

### DIFF
--- a/components/Terminal.vue
+++ b/components/Terminal.vue
@@ -206,11 +206,11 @@ onUnmounted(() => {
     </div>
     <div class="terminal-footer">
       <span>{{ dateTime }}</span>
-      <span class="footer-sep">|</span>
+      <span class="separator">|</span>
       <span>{{ language }}</span>
-      <span class="footer-sep">|</span>
+      <span class="separator">|</span>
       <span>{{ deviceOS }}</span>
-      <span class="footer-sep">|</span>
+      <span class="separator">|</span>
       <span>{{ browser }}</span>
     </div>
   </div>
@@ -429,7 +429,7 @@ onUnmounted(() => {
   display: none;
 }
 
-.footer-sep {
+.separator {
   color: var(--vp-c-text-3);
   user-select: none;
 }

--- a/components/Terminal.vue
+++ b/components/Terminal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from "vue";
+import { ref, onMounted, onUnmounted, computed } from "vue";
 import { useData } from "vitepress";
 
 withDefaults(
@@ -71,6 +71,24 @@ const conversation = computed(
 );
 
 const systemInfo = ref("");
+const currentTime = ref(new Date());
+let timer: ReturnType<typeof setInterval>;
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+const dateTime = computed(() => {
+  const date = currentTime.value;
+  const offset = -date.getTimezoneOffset();
+  const offsetHours = Math.floor(Math.abs(offset) / 60);
+  const offsetMinutes = Math.abs(offset) % 60;
+  const sign = offset >= 0 ? "+" : "-";
+  const utcOffset =
+    offsetMinutes > 0
+      ? `utc${sign}${offsetHours}:${pad(offsetMinutes)}`
+      : `utc${sign}${offsetHours}`;
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return `${date.toLocaleString()} ${utcOffset} ${timezone}`;
+});
 
 const BROWSER_PATTERNS = [
   { pattern: /Firefox\/([\d.]+)/, name: "Firefox" },
@@ -130,6 +148,13 @@ const initSystemInfo = (): void => {
 
 onMounted(() => {
   initSystemInfo();
+  timer = setInterval(() => {
+    currentTime.value = new Date();
+  }, 1000);
+});
+
+onUnmounted(() => {
+  clearInterval(timer);
 });
 
 </script>
@@ -181,6 +206,7 @@ onMounted(() => {
     </div>
     <div class="terminal-footer">
       <span>{{ systemInfo }}</span>
+      <span>{{ dateTime }}</span>
     </div>
   </div>
 </template>
@@ -382,6 +408,8 @@ onMounted(() => {
 .terminal-footer {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 16px;
   padding: 8px 16px;
   font-size: 12px;
   line-height: 1.5;

--- a/components/Terminal.vue
+++ b/components/Terminal.vue
@@ -70,7 +70,9 @@ const conversation = computed(
   () => CONVERSATION[lang.value.startsWith("zh") ? "zh" : "en"],
 );
 
-const systemInfo = ref("");
+const language = ref("");
+const deviceOS = ref("");
+const browser = ref("");
 const currentTime = ref(new Date());
 let timer: ReturnType<typeof setInterval>;
 
@@ -139,11 +141,9 @@ const detectDevice = (ua: string): string => {
 
 const initSystemInfo = (): void => {
   const ua = navigator.userAgent;
-  const language = navigator.language || "Unknown";
-  const device = detectDevice(ua);
-  const os = detectOS(ua);
-  const browser = detectBrowser(ua);
-  systemInfo.value = `${language} ${device} ${os} ${browser}`;
+  language.value = navigator.language || "Unknown";
+  deviceOS.value = `${detectDevice(ua)} ${detectOS(ua)}`;
+  browser.value = detectBrowser(ua);
 };
 
 onMounted(() => {
@@ -205,8 +205,13 @@ onUnmounted(() => {
       <div class="divider" />
     </div>
     <div class="terminal-footer">
-      <span>{{ systemInfo }}</span>
       <span>{{ dateTime }}</span>
+      <span class="footer-sep">|</span>
+      <span>{{ language }}</span>
+      <span class="footer-sep">|</span>
+      <span>{{ deviceOS }}</span>
+      <span class="footer-sep">|</span>
+      <span>{{ browser }}</span>
     </div>
   </div>
 </template>
@@ -408,8 +413,7 @@ onUnmounted(() => {
 .terminal-footer {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 16px;
+  gap: 8px;
   padding: 8px 16px;
   font-size: 12px;
   line-height: 1.5;
@@ -423,6 +427,11 @@ onUnmounted(() => {
 
 .terminal-footer::-webkit-scrollbar {
   display: none;
+}
+
+.footer-sep {
+  color: var(--vp-c-text-3);
+  user-select: none;
 }
 
 .terminal-input::before,

--- a/components/Terminal.vue
+++ b/components/Terminal.vue
@@ -86,8 +86,8 @@ const dateTime = computed(() => {
   const sign = offset >= 0 ? "+" : "-";
   const utcOffset =
     offsetMinutes > 0
-      ? `utc${sign}${offsetHours}:${pad(offsetMinutes)}`
-      : `utc${sign}${offsetHours}`;
+      ? `UTC${sign}${offsetHours}:${pad(offsetMinutes)}`
+      : `UTC${sign}${offsetHours}`;
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   return `${date.toLocaleString()} ${utcOffset} ${timezone}`;
 });


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fix horizontal overflow in `Terminal.vue` where `width: 100%` + horizontal `margin` on flex children exceeded container bounds, pushing right-side padding off-screen on mobile
- Move spacing to `padding: 0 4px` on `.terminal-content` and adjust `.logo` padding from `24px` to `20px` to preserve the original `24px` visual indent
- Add live datetime display to terminal footer (updates every second, cleans up on unmount)
- Split footer into four parts: `datetime | language | device+os | browser` with `|` pipe separators in `text-3` color
- Uppercase UTC offset prefix (`UTC+11` instead of `utc+11`)

## Test plan

- [ ] Open site on mobile and verify right-side padding is visible without horizontal scrolling
- [ ] Verify terminal footer shows all four parts separated by pipes
- [ ] Verify datetime ticks every second with correct UTC offset and timezone
- [ ] Verify layout looks correct on desktop (≥640px)

https://claude.ai/code/session_01FnheW3gZjRPt6iG7hLHtB3
EOF
)