### PR TITLE
fix: sync EN/ZH translation gaps across Portfolio, Resume, Terminal, and use page

### DIFF
--- a/components/Portfolio.vue
+++ b/components/Portfolio.vue
@@ -57,15 +57,16 @@ const PORTFOLIO: Record<string, PortfolioItem[]> = {
       name: "客户营销旅程",
       company: "REA 集团",
       description:
-        "构建了数据管道，将客户画像整合为可营销的受众群体，在营销平台上为房产中介提供全渠道触达能力，提升客户参与度。",
+        "构建了数据管道，将客户画像整合为可营销的受众群体，实现了营销通知管理，在营销平台上为房产中介提供全渠道触达能力，提升客户参与度。",
       techStack: ["TypeScript", "GraphQL", "PostgreSQL", "Kafka"],
     },
     {
-    name: "变更管理工具",
-    company: "AWS",
-    description: "负责变更管理工具的维护与迭代，支持内部团队对软件系统和基础设施的变更进行定义、审核、调度与执行，实施规范化的变更治理。构建了变更自动化，提高变更效率并减少人工操作负担。",
-    techStack: ["Java", "TypeScript", "Python", "DynamoDB", "Elasticsearch", "PostgreSQL", "CDK"],
-  },
+      name: "变更管理工具",
+      company: "AWS",
+      description:
+        "负责变更管理工具的维护与迭代，支持内部团队对软件系统和基础设施的变更进行定义、审核、调度与执行，实施规范化的变更治理。构建了变更自动化，提高变更效率并减少人工操作负担。",
+      techStack: ["Java", "TypeScript", "Python", "DynamoDB", "Elasticsearch", "PostgreSQL", "CDK"],
+    },
   ],
 };
 

--- a/components/Resume.vue
+++ b/components/Resume.vue
@@ -70,7 +70,7 @@ const RESUME: Record<string, ResumeSection[]> = {
           name: "REA 集团",
           location: "澳大利亚墨尔本",
           items: [
-            { label: "高级软件工程师", period: "2025 - Present" },
+            { label: "高级软件工程师", period: "2025 - 至今" },
             { label: "软件工程师", period: "2024 - 2025" },
           ],
         },

--- a/components/Terminal.vue
+++ b/components/Terminal.vue
@@ -270,13 +270,13 @@ onUnmounted(() => {
       <div class="input-border">{{ "─".repeat(numChars) }}</div>
     </div>
     <div class="terminal-footer">
-      <span>Language: {{ language }}</span>
+      <span>{{ isZh ? "语言" : "Language" }}: {{ language }}</span>
       <span class="separator">|</span>
-      <span>Device: {{ device }}</span>
+      <span>{{ isZh ? "设备" : "Device" }}: {{ device }}</span>
       <span class="separator">|</span>
-      <span>Operating System: {{ operatingSystem }}</span>
+      <span>{{ isZh ? "操作系统" : "Operating System" }}: {{ operatingSystem }}</span>
       <span class="separator">|</span>
-      <span>Browser: {{ browser }}</span>
+      <span>{{ isZh ? "浏览器" : "Browser" }}: {{ browser }}</span>
     </div>
   </div>
 </template>

--- a/zh/use.md
+++ b/zh/use.md
@@ -21,7 +21,7 @@
 - 显卡：ASUS NVIDIA GeForce GTX 3060
 - 冷却：Cooler Master MasterLiquid ML240L V2
 - 机箱：Fractal Design Pop Mini Air RGB White Micro ATX
-- 电源：upply: Fractal Design ION Gold 750W
+- 电源：Fractal Design ION Gold 750W
 - 内存：Kingston Fury Beast RGB 2x16GB
 - 硬盘：Samsung 980 Pro 1TB
 


### PR DESCRIPTION
- Portfolio.vue: add missing 营销通知管理 detail to Customer Marketing Journey zh description; fix indentation of 变更管理工具 zh entry
- Resume.vue: translate "Present" → "至今" in zh Senior Software Engineer period
- Terminal.vue: translate footer labels (Language/Device/Operating System/Browser) for zh locale
- zh/use.md: remove stray "upply:" artifact left from partial translation of "Power Supply:"

https://claude.ai/code/session_01NSmaQEKspYy8iWMBHXmkX4