### PR TITLE
Add date frontmatter to blog posts, remove number prefixes, sort by date desc

### DIFF
--- a/components/Blog.vue
+++ b/components/Blog.vue
@@ -16,8 +16,10 @@ defineProps<{
     <ul class="item-list">
       <li v-for="post in posts" :key="post.url" class="item">
         <a :href="post.url" class="item-link">
-          <span class="item-title">{{ post.title }}</span>
-          <span class="item-date">{{ post.date }}</span>
+          <div class="item-header">
+            <span class="item-title">{{ post.title }}</span>
+            <span class="item-date">{{ post.date }}</span>
+          </div>
           <p class="item-description">{{ post.description }}</p>
         </a>
       </li>
@@ -49,6 +51,12 @@ defineProps<{
   padding-left: 16px;
 }
 
+.item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
 .item-title {
   font-weight: 600;
   color: var(--vp-c-text-1);
@@ -57,8 +65,21 @@ defineProps<{
 }
 
 .item-date {
-  font-size: 13px;
-  color: var(--vp-c-text-3);
+  font-size: 14px;
+  font-style: italic;
+  color: var(--vp-c-text-2);
+  white-space: nowrap;
+}
+
+@media (max-width: 639px) {
+  .item-header {
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .item-date {
+    white-space: normal;
+  }
 }
 
 .item-link:hover {

--- a/components/Blog.vue
+++ b/components/Blog.vue
@@ -3,6 +3,7 @@ type Post = {
   title: string;
   url: string;
   description: string;
+  date: string;
 };
 
 defineProps<{
@@ -16,6 +17,7 @@ defineProps<{
       <li v-for="post in posts" :key="post.url" class="item">
         <a :href="post.url" class="item-link">
           <span class="item-title">{{ post.title }}</span>
+          <span class="item-date">{{ post.date }}</span>
           <p class="item-description">{{ post.description }}</p>
         </a>
       </li>
@@ -52,6 +54,11 @@ defineProps<{
   color: var(--vp-c-text-1);
   flex: 1;
   min-width: 0;
+}
+
+.item-date {
+  font-size: 13px;
+  color: var(--vp-c-text-3);
 }
 
 .item-link:hover {

--- a/en/blog/blog.data.ts
+++ b/en/blog/blog.data.ts
@@ -4,6 +4,7 @@ export type Post = {
   title: string;
   url: string;
   description: string;
+  date: string;
 };
 
 declare const data: Post[];
@@ -18,7 +19,8 @@ export default createContentLoader(["en/blog/*.md", "en/blog/*/*.md"], {
         title: item.frontmatter.title ?? item.src?.match(/^#\s+(.+)/m)?.[1].trim() ?? "",
         url: item.url.replace(/^\/en\//, "/"),
         description: item.frontmatter.description ?? "",
+        date: item.frontmatter.date ?? "",
       }))
-      .sort((a, b) => a.url.localeCompare(b.url));
+      .sort((a, b) => b.date.localeCompare(a.date));
   },
 });

--- a/en/blog/inside-claude-code/anti-distillation-and-undercover-mode.md
+++ b/en/blog/inside-claude-code/anti-distillation-and-undercover-mode.md
@@ -1,5 +1,6 @@
 ---
 description: "Claude Code has two hidden defensive mechanisms."
+date: 2025-04-05
 ---
 
 # Inside Claude Code: Anti-Distillation and Undercover Mode

--- a/en/blog/inside-claude-code/anti-distillation-and-undercover-mode.md
+++ b/en/blog/inside-claude-code/anti-distillation-and-undercover-mode.md
@@ -1,6 +1,6 @@
 ---
 description: "Claude Code has two hidden defensive mechanisms."
-date: 2025-04-05
+date: 2026-04-05
 ---
 
 # Inside Claude Code: Anti-Distillation and Undercover Mode

--- a/en/blog/inside-claude-code/five-level-context-compression.md
+++ b/en/blog/inside-claude-code/five-level-context-compression.md
@@ -1,6 +1,6 @@
 ---
 description: "Claude Code has a five-level pipeline to compress context."
-date: 2025-03-22
+date: 2026-03-22
 ---
 
 # Inside Claude Code: Five-Level Context Compression

--- a/en/blog/inside-claude-code/five-level-context-compression.md
+++ b/en/blog/inside-claude-code/five-level-context-compression.md
@@ -1,5 +1,6 @@
 ---
 description: "Claude Code has a five-level pipeline to compress context."
+date: 2025-03-22
 ---
 
 # Inside Claude Code: Five-Level Context Compression

--- a/en/blog/inside-claude-code/overview.md
+++ b/en/blog/inside-claude-code/overview.md
@@ -1,6 +1,6 @@
 ---
 description: "Everything in Claude Code is built on concepts working engineers have encountered before."
-date: 2025-02-01
+date: 2026-02-01
 ---
 
 # Inside Claude Code: Overview

--- a/en/blog/inside-claude-code/overview.md
+++ b/en/blog/inside-claude-code/overview.md
@@ -1,5 +1,6 @@
 ---
 description: "Everything in Claude Code is built on concepts working engineers have encountered before."
+date: 2025-02-01
 ---
 
 # Inside Claude Code: Overview

--- a/en/blog/inside-claude-code/read-write-concurrency-separation.md
+++ b/en/blog/inside-claude-code/read-write-concurrency-separation.md
@@ -1,5 +1,6 @@
 ---
 description: "Claude Code handles concurrent tool execution by borrowing a classic database pattern."
+date: 2025-02-22
 ---
 
 # Inside Claude Code: Read/Write Concurrency Separation

--- a/en/blog/inside-claude-code/read-write-concurrency-separation.md
+++ b/en/blog/inside-claude-code/read-write-concurrency-separation.md
@@ -1,6 +1,6 @@
 ---
 description: "Claude Code handles concurrent tool execution by borrowing a classic database pattern."
-date: 2025-02-22
+date: 2026-02-22
 ---
 
 # Inside Claude Code: Read/Write Concurrency Separation

--- a/en/blog/inside-claude-code/retrieval-strategy.md
+++ b/en/blog/inside-claude-code/retrieval-strategy.md
@@ -1,5 +1,6 @@
 ---
 description: "Claude Code skips RAG, instead using a three-layer architecture of metadata scanning."
+date: 2025-03-08
 ---
 
 # Inside Claude Code: Retrieval Strategy

--- a/en/blog/inside-claude-code/retrieval-strategy.md
+++ b/en/blog/inside-claude-code/retrieval-strategy.md
@@ -1,6 +1,6 @@
 ---
 description: "Claude Code skips RAG, instead using a three-layer architecture of metadata scanning."
-date: 2025-03-08
+date: 2026-03-08
 ---
 
 # Inside Claude Code: Retrieval Strategy

--- a/en/blog/inside-claude-code/security-layer.md
+++ b/en/blog/inside-claude-code/security-layer.md
@@ -1,5 +1,6 @@
 ---
 description: "Claude Code has a `--dangerously-skip-permissions` flag, also known as YOLO mode."
+date: 2025-03-29
 ---
 
 # Inside Claude Code: Security Layer

--- a/en/blog/inside-claude-code/security-layer.md
+++ b/en/blog/inside-claude-code/security-layer.md
@@ -1,6 +1,6 @@
 ---
 description: "Claude Code has a `--dangerously-skip-permissions` flag, also known as YOLO mode."
-date: 2025-03-29
+date: 2026-03-29
 ---
 
 # Inside Claude Code: Security Layer

--- a/en/blog/inside-claude-code/system-prompt-cache-splitting.md
+++ b/en/blog/inside-claude-code/system-prompt-cache-splitting.md
@@ -1,6 +1,6 @@
 ---
 description: "Claude Code splits its system prompt at a sentinel boundary to maximise Anthropic API cache hits."
-date: 2025-03-01
+date: 2026-03-01
 ---
 
 # Inside Claude Code: System Prompt Cache Splitting

--- a/en/blog/inside-claude-code/system-prompt-cache-splitting.md
+++ b/en/blog/inside-claude-code/system-prompt-cache-splitting.md
@@ -1,5 +1,6 @@
 ---
 description: "Claude Code splits its system prompt at a sentinel boundary to maximise Anthropic API cache hits."
+date: 2025-03-01
 ---
 
 # Inside Claude Code: System Prompt Cache Splitting

--- a/en/blog/inside-claude-code/the-agent-loop.md
+++ b/en/blog/inside-claude-code/the-agent-loop.md
@@ -1,6 +1,6 @@
 ---
 description: "Claude Code is actually using a while(true) loop."
-date: 2025-02-08
+date: 2026-02-08
 ---
 
 # Inside Claude Code: The Agent Loop

--- a/en/blog/inside-claude-code/the-agent-loop.md
+++ b/en/blog/inside-claude-code/the-agent-loop.md
@@ -1,5 +1,6 @@
 ---
 description: "Claude Code is actually using a while(true) loop."
+date: 2025-02-08
 ---
 
 # Inside Claude Code: The Agent Loop

--- a/en/blog/inside-claude-code/three-tier-memory-architecture.md
+++ b/en/blog/inside-claude-code/three-tier-memory-architecture.md
@@ -1,5 +1,6 @@
 ---
 description: "Claude Code solves AI context drift with a three-tier memory architecture."
+date: 2025-03-15
 ---
 
 # Inside Claude Code: Three-Tier Memory Architecture

--- a/en/blog/inside-claude-code/three-tier-memory-architecture.md
+++ b/en/blog/inside-claude-code/three-tier-memory-architecture.md
@@ -1,6 +1,6 @@
 ---
 description: "Claude Code solves AI context drift with a three-tier memory architecture."
-date: 2025-03-15
+date: 2026-03-15
 ---
 
 # Inside Claude Code: Three-Tier Memory Architecture

--- a/en/blog/inside-claude-code/tool-design.md
+++ b/en/blog/inside-claude-code/tool-design.md
@@ -1,5 +1,6 @@
 ---
 description: "Claude Code's built-in tools."
+date: 2025-02-15
 ---
 
 # Inside Claude Code: Tool Design

--- a/en/blog/inside-claude-code/tool-design.md
+++ b/en/blog/inside-claude-code/tool-design.md
@@ -1,6 +1,6 @@
 ---
 description: "Claude Code's built-in tools."
-date: 2025-02-15
+date: 2026-02-15
 ---
 
 # Inside Claude Code: Tool Design

--- a/en/blog/mastering-claude-code-in-30-minutes.md
+++ b/en/blog/mastering-claude-code-in-30-minutes.md
@@ -1,5 +1,6 @@
 ---
 description: "Learn advanced features, shortcuts, and workflows to get the most from Claude Code."
+date: 2025-01-01
 ---
 
 # Mastering Claude Code in 30 minutes

--- a/en/blog/mastering-claude-code-in-30-minutes.md
+++ b/en/blog/mastering-claude-code-in-30-minutes.md
@@ -1,6 +1,6 @@
 ---
 description: "Learn advanced features, shortcuts, and workflows to get the most from Claude Code."
-date: 2025-01-01
+date: 2026-01-01
 ---
 
 # Mastering Claude Code in 30 minutes


### PR DESCRIPTION
- Add date frontmatter to all inside-claude-code posts (2025-02-01 through
  2025-04-05, weekly intervals matching the 00–09 series order)
- Add date: 2025-01-01 to mastering-claude-code (earliest in the index)
- Rename inside-claude-code files to drop the numeric prefix (e.g.
  00-overview.md → overview.md)
- Update blog.data.ts: add date field to Post type, sort descending by date

https://claude.ai/code/session_01BUnSUo19QpcNoqjgjifqtJ