### PR TITLE
Sort blog index by date

### DIFF
--- a/en/blog/blog.data.ts
+++ b/en/blog/blog.data.ts
@@ -19,7 +19,7 @@ export default createContentLoader(["en/blog/*.md", "en/blog/*/*.md"], {
         title: item.frontmatter.title ?? item.src?.match(/^#\s+(.+)/m)?.[1].trim() ?? "",
         url: item.url.replace(/^\/en\//, "/"),
         description: item.frontmatter.description ?? "",
-        date: item.frontmatter.date ?? "",
+        date: item.frontmatter.date ? new Date(item.frontmatter.date).toISOString().slice(0, 10) : "",
       }))
       .sort((a, b) => b.date.localeCompare(a.date));
   },


### PR DESCRIPTION
- Add `date` frontmatter to all blog posts and sort index descending by date
- Remove numeric prefixes from `inside-claude-code` filenames
- Display date in `Blog.vue` matching `Portfolio.vue` company field styling

https://claude.ai/code/session_01BUnSUo19QpcNoqjgjifqtJ