### PR TITLE
Update blog tag badge background color to brand-2

### DIFF
--- a/components/Blog.vue
+++ b/components/Blog.vue
@@ -112,6 +112,6 @@ defineProps<{
   font-size: 0.75rem;
   font-weight: 500;
   color: var(--vp-c-text-1);
-  background-color: var(--vp-c-brand-1);
+  background-color: var(--vp-c-brand-2);
 }
 </style>


### PR DESCRIPTION
## Summary

- Change badge background color from `--vp-c-brand-1` to `--vp-c-brand-2`

## Test plan

- [ ] Check badge appearance in light mode
- [ ] Check badge appearance in dark mode

https://claude.ai/code/session_01Qz1wn5qdtLtT7TcmcxE6W4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz1wn5qdtLtT7TcmcxE6W4)_